### PR TITLE
Avoid random values repetition

### DIFF
--- a/jobs/query_builder.py
+++ b/jobs/query_builder.py
@@ -12,8 +12,9 @@ def param_occurances_multiple_values(input_str, param, param_list):
     resutls = re.findall(rf"{param}:(.*?)#", input_str)
     for replace_values in resutls:
         random_param = ""
-        for i in range(int(replace_values)):
-            random_param = f"{random_param},'{random.choice(param_list)}'"
+        random_sample = random.sample(param_list, k=random.randint(1, replace_values))
+        random_sample_str = ','.join([f"'{x}'" for x in random_sample])
+        random_param = f"{random_param},{random_sample_str}"
         # input_str = input_str.replace(
         #     f"${param}:{int(replace_values)}#", random_param.lstrip(",")
         param_is = f"\${param}"


### PR DESCRIPTION
Random values substituted in `param_occurances_multiple_values` made unique using `random.sample`

Sample code check:

      >>> param_list
      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
      >>> random_param = ""
      >>> random_sample = random.sample(param_list, k=random.randint(1, replace_values))
      >>> random_sample
      [4, 1, 7, 10, 8, 11, 2]
      >>> random_sample_str = ','.join([f"'{x}'" for x in random_sample])
      >>> random_sample_str
      "'4','1','7','10','8','11','2'"
      >>> random_param = f"{random_param},{random_sample_str}"
      >>> random_param
      ",'4','1','7','10','8','11','2'"
