### PR TITLE
Fixed repetition in random value generation

### DIFF
--- a/jobs/query_builder.py
+++ b/jobs/query_builder.py
@@ -12,8 +12,9 @@ def param_occurances_multiple_values(input_str, param, param_list):
     resutls = re.findall(rf"{param}:(.*?)#", input_str)
     for replace_values in resutls:
         random_param = ""
-        for i in range(int(replace_values)):
-            random_param = f"{random_param},'{random.choice(param_list)}'"
+        random_sample = random.sample(param_list, k=random.randint(1, int(replace_values)))
+        random_sample_str = ','.join([f"'{x}'" for x in random_sample])
+        random_param = f"{random_param},{random_sample_str}"
         # input_str = input_str.replace(
         #     f"${param}:{int(replace_values)}#", random_param.lstrip(",")
         param_is = f"\${param}"


### PR DESCRIPTION
Random values substituted in `param_occurances_multiple_values` made unique using `random.sample`

Sample code check:

    >>> replace_values = '10'
    >>> param_list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
    >>> random_param = ""
    >>> random_sample = random.sample(param_list, k=random.randint(1, int(replace_values)))
    >>> random_sample
    [9, 2, 3, 5, 6, 10]
    >>> random_sample_str = ','.join([f"'{x}'" for x in random_sample])
    >>> random_sample_str
    "'9','2','3','5','6','10'"
    >>> random_param = f"{random_param},{random_sample_str}"
    >>> random_param
    ",'9','2','3','5','6','10'"
